### PR TITLE
MongoDB template fixes for RHEL/CentOS/Fedora.

### DIFF
--- a/templates/mongodb-org-3.2.repo.j2
+++ b/templates/mongodb-org-3.2.repo.j2
@@ -1,7 +1,11 @@
 {# Note: expected ansible_distribution is "Amazon" or "RedHat" to be compatible with yum repos listed here https://docs.mongodb.com/manual/tutorial/install-mongodb-on-red-hat/ -#}
 [mongodb-org-3.2]
 name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/{{ ansible_distribution|lower }}/2013.03/mongodb-org/3.2/x86_64/
+{% if ansible_distribution == "Amazon" %}
+  baseurl=https://repo.mongodb.org/yum/amazon/2013.03/mongodb-org/3.2/x86_64/
+{% else %}
+  baseurl=https://repo.mongodb.org/yum/redhat/{{ ansible_lsb.major_release|int }}/mongodb-org/3.2/x86_64/
+{% endif %}
 gpgcheck=1
 enabled=1
 gpgkey=https://www.mongodb.org/static/pgp/server-3.2.asc


### PR DESCRIPTION
Just tried to deploy this to a CentOS 7.x server, and found that the MongoDB repo template generated a URL that didn't exist:

`https://repo.mongodb.org/yum/centos/2013.03/mongodb-org/3.2/x86_64/`

As CentOS and Red Hat are very similar (and the RHEL package works perfectly on CentOS) I have made a small change to the template to select the correct RHEL repo for CentOS/RHEL (and probably Fedora too).

The change allowed me to successfully deploy this role to my CentOS 7 server, so I thought I'd contribute this back, in case anyone else wants CentOS support! Note that for non-RedHat distros, `redhat-lsb-core` will need to be installed before this role is deployed to the host (i.e. manually or in a separate play).